### PR TITLE
Added support for LV 0.18.6

### DIFF
--- a/lib/phosphoricons/icon_generator.ex
+++ b/lib/phosphoricons/icon_generator.ex
@@ -75,7 +75,9 @@ defmodule Phosphoricons.IconGenerator do
             file: __ENV__.file,
             line: __ENV__.line + 1,
             module: __ENV__.module,
-            indentation: 0
+            indentation: 0,
+            caller: __ENV__,
+            source: head <> "{@attrs}" <> body
           )
         )
       end


### PR DESCRIPTION
There were some breaking changes in LiveView 0.18.6. The package wasn't compiling with `KeyError`. The `EEx.compile_string` function now requires `caller` and `source` to be passed. This fixes it.